### PR TITLE
test-syslog.yml

### DIFF
--- a/test-syslog.yml
+++ b/test-syslog.yml
@@ -1,0 +1,12 @@
+# Ansible/Tower test logging to remote hosts
+- name: Test syslog
+  syslogger:
+    msg: "Hello from ansible"
+    priority: "err"
+    facility: "daemon"
+    log_pid: true
+
+# Basic usage
+- name: Simple Usage
+  syslogger:
+    msg: "I will end up as daemon.info"


### PR DESCRIPTION
This is a new file created to test logging from ansible/tower to target hosts through syslog_facility. Note /etc/ansible/ansible.cfg has been configured with the no_/target_syslog = False.