### PR TITLE
Post Install pre-seeded content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# ansible-tower-samples
+# ARCHIVED: ansible-tower-samples
 Ansible Tower Playbook Samples
+
+This repo is now archived, and its functionality split into the [product-demos-postinstall](https://github.com/ansible/product-demos-postinstall) and [product-demos-bootstrap](https://github.com/ansible/product-demos-bootstrap) repos instead.  Please use these new repos when setting up [Ansible Product Demos](https://github.com/ansible/product-demos) in Ansible Automation Platform.
 
 ## Using this Repo
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # ansible-tower-samples
 Ansible Tower Playbook Samples
+
+## Using this Repo
+
+
+### Step 1 - Install Ansible Automation Platform
+Presumably you have already completed this step before arriving here, however the installation of Automation Controller needs to be completed before you continue.
+
+### Step 2 - Edit the Demo Project
+1. Login to your Automation Controller as the `admin` user and click on **Project** in the left hand sidebar.
+2. Click on the **Demo Project** and edit it. Change the **Source Control URL** to `https://github.com/RedHatGov/ansible-tower-samples` and save the project.
+3. Make sure the project sync completes.
+
+### Step 3 - Create the Controller Credential
+1. Navigate to the **Credentials** section in the left hand sidebar.
+2. Click the **Add** button at the top of the screen and use the following values to create your credential.
+
+|      |                       |
+|------|-----------------------|
+| Name | 'Controller Credential' |
+| Organization | 'Default' |
+| Credential Type | 'Red Hat Ansible Automation Platform' |
+| Red Hat Ansible Automation Platform | *URL of Controller UI* |
+| Username | 'admin' |
+| Password | *admin password* |
+
+### Step 4 - Edit the Demo Job Template
+1. Navigate to the **Templates** section in the left hand sidebar.
+2. Click on the **Demo Job Template** and edit it. Change the **playbook** field to `product_demos.yml`. If you do not see this option, go back to step 2 and ensure your project is configured and synced properly.
+3. Click the magnifying glass on the **Credentials** field, change the dropdown in the top right to `Red Hat Ansible Automation Platform` and select `Controller Credential` from the list.
+4. Save the job template and click **Launch**
+
+#### Customization: If you have customized the product-demos project, now would be the time to update the source URL for your project.
+
+### Step 5 - Launch the SETUP Job
+1. Navigate back to the **Templates** section in the left hand sidebar.
+2. Locate the **SETUP** job template and click the rocket ship icon on the right to launch the job.
+3. Select the use case from the dropdown that you are interested in and continue.
+
+
+#### You have now completed the setup. Refer to [ansible/product-demos](https://github.com/ansible/product-demos) for further documentation.
+
+---
+
+[Privacy statement](https://www.redhat.com/en/about/privacy-policy) | [Terms of use](https://www.redhat.com/en/about/terms-use) | [Security disclosure](https://www.ansible.com/security?hsLang=en-us) | [All policies and guidelines](https://www.redhat.com/en/about/all-policies-guidelines)

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  - name: infra.controller_configuration
+    version: 2.5.0
+  - name: awx.awx
+    version: 22.7.0

--- a/product_demos.yml
+++ b/product_demos.yml
@@ -29,7 +29,7 @@
         organization: Default
         scm_type: git
         scm_url: "{{ product_demos_url | default('https://github.com/ansible/product-demos') }}"
-        scm_branch: "{{ product_demos_branch | default('main') }}"
+        scm_branch: creds-exist #"{{ product_demos_branch | default('main') }}"
         wait: true
     controller_templates:
       - name: "SETUP"
@@ -55,6 +55,17 @@
                 - network
                 - openshift
                 - satellite
+        extra_vars:
+          operation_translate:
+            present:
+              verb: "Create/Update"
+              action: "creation"
+            absent:
+              verb: "Remove"
+              action: "deletion"
+            exists:
+              verb: "Already Exists"
+              action: "exists"
 
       - name: "Multi-SETUP demos"
         project: "Ansible official demo project"
@@ -78,6 +89,17 @@
                 - openshift
                 - satellite
                 - windows
+        extra_vars:
+          operation_translate:
+            present:
+              verb: "Create/Update"
+              action: "creation"
+            absent:
+              verb: "Remove"
+              action: "deletion"
+            exists:
+              verb: "Already Exists"
+              action: "exists"
 
     user_message:
       - Run the SETUP job template and select a use case

--- a/product_demos.yml
+++ b/product_demos.yml
@@ -29,7 +29,7 @@
         organization: Default
         scm_type: git
         scm_url: "{{ product_demos_url | default('https://github.com/ansible/product-demos') }}"
-        scm_branch: creds-exist #"{{ product_demos_branch | default('main') }}"
+        scm_branch: "{{ product_demos_branch | default('main') }}"
         wait: true
     controller_templates:
       - name: "SETUP"

--- a/product_demos.yml
+++ b/product_demos.yml
@@ -28,7 +28,7 @@
       - name: Ansible official demo project
         organization: Default
         scm_type: git
-        scm_url: https://github.com/ansible/product-demos
+        scm_url: "{{ product_demos_url | default('https://github.com/ansible/product-demos') }}"
         scm_branch: "{{ product_demos_branch | default('main') }}"
         wait: true
     controller_templates:
@@ -55,6 +55,30 @@
                 - network
                 - openshift
                 - satellite
+
+      - name: "Multi-SETUP demos"
+        project: "Ansible official demo project"
+        playbook: "multi_select_setup.yml"
+        inventory: "Demo Inventory"
+        credentials: "Controller Credential"
+        survey_enabled: true
+        survey:
+          name: ''
+          description: ''
+          spec:
+            - question_name: "Which demos do you want to configure?"
+              type: multiselect
+              variable: demos
+              required: true
+              default: "cloud\nlinux\nnetwork\nopenshift\nwindows"
+              choices:
+                - cloud
+                - linux
+                - network
+                - openshift
+                - satellite
+                - windows
+
     user_message:
       - Run the SETUP job template and select a use case
       - Find more documentation at https://github.com/ansible/product-demos/

--- a/product_demos.yml
+++ b/product_demos.yml
@@ -2,7 +2,6 @@
 - name: Configure for Ansible Product Demos
   hosts: localhost
   vars:
-    product_demos_branch: rhpd_test
     controller_validate_certs: false
     controller_settings:
       - name: AWX_COLLECTIONS_ENABLED

--- a/product_demos.yml
+++ b/product_demos.yml
@@ -29,7 +29,7 @@
       - name: Ansible official demo project
         organization: Default
         scm_type: git
-        scm_url: https://github.com/RedHatGov/product-demos
+        scm_url: https://github.com/ansible/product-demos
         scm_branch: "{{ product_demos_branch | default('main') }}"
         wait: true
     controller_templates:

--- a/product_demos.yml
+++ b/product_demos.yml
@@ -3,6 +3,9 @@
   hosts: localhost
   vars:
     controller_validate_certs: false
+    controller_settings:
+      - name: AWX_COLLECTIONS_ENABLED
+        value: "false"
     controller_credentials:
       - name: Automation Hub
         organization: Default
@@ -26,7 +29,7 @@
         organization: Default
         scm_type: git
         scm_url: https://github.com/RedHatGov/product-demos
-        scm_branch: "{{ product_demos_branch | default(main) }}"
+        scm_branch: "{{ product_demos_branch | default('main') }}"
         wait: true
     controller_templates:
       - name: "SETUP"
@@ -57,10 +60,10 @@
 
   tasks:
   - name: Setup Components
-    ansible.builtin.include_role:
-      name: "infra.controller_configuration.disapatch"
+    include_role:
+      name: infra.controller_configuration.dispatch
 
   - name: Print Message
-    anisble.builtin.debug:
+    debug:
       msg: "{{ user_message }}"
     when: user_message is defined

--- a/product_demos.yml
+++ b/product_demos.yml
@@ -1,0 +1,66 @@
+---
+- name: Configure for Ansible Product Demos
+  hosts: localhost
+  vars:
+    controller_validate_certs: false
+    controller_credentials:
+      - name: Automation Hub
+        organization: Default
+        credential_type: Ansible Galaxy/Automation Hub API Token
+        update_secrets: false
+        inputs:
+          url: https://console.redhat.com/api/automation-hub/
+          auth_url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+    controller_execution_environments:
+      - name: product-demos
+        image: quay.io/acme_corp/product-demos-ee:latest
+    controller_organizations:
+      - name: Default
+        default_environment:
+          name: 'product-demos'
+        galaxy_credentials:
+          - Ansible Galaxy
+          - Automation Hub
+    controller_projects:
+      - name: Ansible official demo project
+        organization: Default
+        scm_type: git
+        scm_url: https://github.com/RedHatGov/product-demos
+        scm_branch: "{{ product_demos_branch | default(main) }}"
+        wait: true
+    controller_templates:
+      - name: "SETUP"
+        job_type: run
+        inventory: "Demo Inventory"
+        project: "Ansible official demo project"
+        playbook: "setup_demo.yml"
+        credentials: "Controller Credential"
+        allow_simultaneous: true
+        survey_enabled: true
+        survey_spec:
+          name: 'Survey'
+          description: ''
+          spec:
+            - type: multiplechoice
+              question_name: Demo Category
+              variable: demo
+              required: true
+              choices:
+                - linux
+                - windows
+                - cloud
+                - network
+                - satellite
+    user_message:
+      - Run the SETUP job template and select a use case
+      - Find more documentation at https://github.com/ansible/product-demos/
+
+  tasks:
+  - name: Setup Components
+    ansible.builtin.include_role:
+      name: "infra.controller_configuration.disapatch"
+
+  - name: Print Message
+    anisble.builtin.debug:
+      msg: "{{ user_message }}"
+    when: user_message is defined

--- a/product_demos.yml
+++ b/product_demos.yml
@@ -53,6 +53,7 @@
                 - windows
                 - cloud
                 - network
+                - openshift
                 - satellite
     user_message:
       - Run the SETUP job template and select a use case

--- a/product_demos.yml
+++ b/product_demos.yml
@@ -2,6 +2,7 @@
 - name: Configure for Ansible Product Demos
   hosts: localhost
   vars:
+    product_demos_branch: rhpd_test
     controller_validate_certs: false
     controller_settings:
       - name: AWX_COLLECTIONS_ENABLED


### PR DESCRIPTION
This PR enables customers to use the product to bootstrap itself for demo content from https://github.com/ansible/product-demos. The README contains prerequisites for running the product_demos.yml playbook. In summary, this requires the creation of a `Controller Credential` and updating the `Demo Job Template`.

The product_demos playbook itself configures additional requirements for the pre-seeded content detailed here:
1) Disable collection download - removed dependency on AH and use EE instead
2) Create a placeholder Automation Hub Cred - added to the organization in case the user needs to source from AH
3) Add Product-Demos EE - add the EE with required collections to support the pre-seeded content
4) Update the Org - configure the org to default to the product-demos EE and automation hub credential
5) Add the Product-Demos Project - add config as code repo for pre-seeded content
6) Add the Setup Job Template - add job template to deploy pre-seeded content

This procedure reduces friction for customer adoption while enabling customization through the config as code repo.